### PR TITLE
Improve error handling in get_job_info

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -283,8 +283,10 @@ class MessageScheduler:
                         
                         if earliest_send is None or today_time < earliest_send:
                             earliest_send = today_time
-                    except:
-                        pass
+                    except Exception as e:
+                        self.logger.error(
+                            f"Failed to parse scheduled time '{time_str}': {e}"
+                        )
                 
                 job_info["next_message_send"] = earliest_send
                 


### PR DESCRIPTION
## Summary
- handle parsing errors in `get_job_info`

## Testing
- `python -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685a6314a6cc832eb2e092646ed5ff17