### PR TITLE
Fix newline at EOF in scheduler

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -347,3 +347,4 @@ class MessageScheduler:
         except Exception as e:
             self.logger.error(f"Failed to reschedule jobs: {e}")
             return False
+


### PR DESCRIPTION
## Summary
- add a missing newline at the end of `scheduler.py`

## Testing
- `git diff --color --unified=5`

------
https://chatgpt.com/codex/tasks/task_e_685a63cb8b08832ea730c876934cd48e