### PR TITLE
Clean unused typing imports

### DIFF
--- a/database.py
+++ b/database.py
@@ -6,7 +6,7 @@ Handles all SQLite operations for storing and retrieving messages.
 import sqlite3
 import logging
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 import os
 
 

--- a/handlers.py
+++ b/handlers.py
@@ -5,7 +5,6 @@ Handles incoming messages and stores them in the database.
 
 import logging
 import re
-from typing import Optional
 from telegram import Update
 from telegram.ext import ContextTypes, MessageHandler, CommandHandler, filters
 from database import DatabaseManager

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 from telegram.ext import Application
-from telegram import Bot
 from telegram.error import TelegramError
 
 from config import Config

--- a/scheduler.py
+++ b/scheduler.py
@@ -5,7 +5,6 @@ Handles scheduled message sending and cleanup operations using APScheduler.
 
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from telegram import Bot


### PR DESCRIPTION
## Summary
- drop unused `Optional` import in `scheduler.py`
- remove `List` from `database.py` imports
- clean stray typing imports in `handlers.py` and `main.py`

## Testing
- `flake8 | grep F401`

------
https://chatgpt.com/codex/tasks/task_e_685a64d4c4dc832e810b6d7a15ef9ecf